### PR TITLE
Simplify branding and rename War Games page

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,12 +6,13 @@
   <title>About — Mega-Museum</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css" />
+  <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg" />
   <meta name="description" content="About the Mega-Museum project and our long-term plan from 3D comic animation to stop-motion to a real movie." />
 </head>
 <body>
   <!-- NAV -->
   <header class="nav">
-    <a class="brand" href="/"><span class="logo-circle">M</span><span class="brand-text">MEGA-MUSEUM</span></a>
+    <a class="brand" href="/" aria-label="Mega-Museum home"><span class="logo-circle">M</span></a>
     <nav>
       <div class="dropdown">
         <button class="dropbtn">Visit the Museum ▾</button>
@@ -21,7 +22,7 @@
         </div>
       </div>
       <a href="creation.html">Creation Story</a>
-      <a href="game.html">Game</a>
+      <a href="game.html">War Games</a>
       <a href="about.html">About</a>
       <a class="btn primary small" href="/#co-create">Co-Create</a>
     </nav>

--- a/assets/img/favicon.svg
+++ b/assets/img/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e40af"/>
+      <stop offset="100%" stop-color="#0ea5e9"/>
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#grad)"/>
+  <text x="32" y="40" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="800" fill="#ffffff">M</text>
+</svg>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -40,7 +40,6 @@ body{
   display:flex; align-items:center; gap:8px;
   font-weight:800; text-decoration:none; color:var(--ink);
 }
-.brand-text{ font-weight:800; letter-spacing:.8px; }
 
 /* Circle M logo */
 .logo-circle{

--- a/creation.html
+++ b/creation.html
@@ -6,6 +6,7 @@
   <title>Creation Story — Mega-Museum Cinema</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css" />
+  <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg" />
   <meta name="description" content="The Mega-Museum Cinema — watch the co-creation story unfold in video form. Vote on what gets made next." />
 
   <!-- Page-specific styles (kept here to keep this page self-contained) -->
@@ -93,7 +94,7 @@
 <body>
   <!-- NAV -->
   <header class="nav">
-    <a class="brand" href="/"><span class="logo-circle">M</span><span class="brand-text">MEGA-MUSEUM</span></a>
+    <a class="brand" href="/" aria-label="Mega-Museum home"><span class="logo-circle">M</span></a>
     <nav>
       <div class="dropdown">
         <button class="dropbtn">Visit the Museum ▾</button>
@@ -103,7 +104,7 @@
         </div>
       </div>
       <a href="creation.html">Creation Story</a>
-      <a href="game.html">Game</a>
+      <a href="game.html">War Games</a>
       <a href="about.html">About</a>
       <a class="btn primary small" href="/#co-create">Co-Create</a>
     </nav>

--- a/game.html
+++ b/game.html
@@ -3,15 +3,16 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Game — Mega-Museum</title>
+  <title>War Games — Mega-Museum</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css" />
-  <meta name="description" content="Play the interactive Mega-Museum web game and help shape the future of the museum world." />
+  <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg" />
+  <meta name="description" content="Play War Games, the interactive Mega-Museum web experience, and help shape the future of the museum world." />
 </head>
 <body>
   <!-- NAV -->
   <header class="nav">
-    <a class="brand" href="/"><span class="logo-circle">M</span><span class="brand-text">MEGA-MUSEUM</span></a>
+    <a class="brand" href="/" aria-label="Mega-Museum home"><span class="logo-circle">M</span></a>
     <nav>
       <div class="dropdown">
         <button class="dropbtn">Visit the Museum ▾</button>
@@ -21,22 +22,22 @@
         </div>
       </div>
       <a href="creation.html">Creation Story</a>
-      <a href="game.html">Game</a>
+      <a href="game.html">War Games</a>
       <a href="about.html">About</a>
       <a class="btn primary small" href="/#co-create">Co-Create</a>
     </nav>
   </header>
 
   <main class="page-wrap narrow">
-    <h1 class="page-title">Mega-Museum Game</h1>
-    <p>The Mega-Museum game is where our world becomes playable. We’re building a browser-based adventure that lets you wander
-      through evolving rooms, meet characters in motion, and influence the story in real time.</p>
+    <h1 class="page-title">War Games</h1>
+    <p>War Games is where our world becomes playable. We’re building a browser-based adventure that lets you wander through
+      evolving rooms, meet characters in motion, and influence the story in real time.</p>
     <p class="muted">This page will become the hub for playtests, patch notes, and behind-the-scenes dev logs as the experience comes
       online. Check back soon to jump into the first interactive build.</p>
 
     <section class="card" style="margin-top:24px;">
       <h2>Be first to play</h2>
-      <p>Want to know when the prototype launches? Join the co-creation crew so you can test the game, drop feedback, and help
+      <p>Want to know when the prototype launches? Join the co-creation crew so you can test War Games, drop feedback, and help
         decide which mechanics ship.</p>
       <a class="btn primary" href="/#co-create">Join the Co-Creation Polls</a>
     </section>

--- a/how-to.html
+++ b/how-to.html
@@ -6,12 +6,12 @@
   <title>VR & How-to — Mega-Museum</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css" />
+  <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg" />
 </head>
 <body>
 <header class="nav">
-  <a class="brand" href="/">
+  <a class="brand" href="/" aria-label="Mega-Museum home">
     <span class="logo-circle">M</span>
-    <span class="brand-text">MEGA-MUSEUM</span>
   </a>
   <nav>
     <div class="dropdown">
@@ -23,7 +23,7 @@
       </div>
     </div>
     <a href="creation.html">Creation Story</a>
-    <a href="game.html">Game</a>
+    <a href="game.html">War Games</a>
     <a href="about.html">About</a>
     <a class="btn primary small" href="#co-create">Co-Create</a>
   </nav>

--- a/index.html
+++ b/index.html
@@ -6,13 +6,14 @@
   <title>Mega-Museum — A living, evolving art experiment</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css" />
+  <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg" />
   <meta name="description" content="Start inside simple prototype rooms. Return to see them transform. Vote on what gets built next." />
 </head>
 <body>
 
   <!-- NAV -->
   <header class="nav">
-    <a class="brand" href="/"><span class="logo-circle">M</span><span class="brand-text">MEGA-MUSEUM</span></a>
+    <a class="brand" href="/" aria-label="Mega-Museum home"><span class="logo-circle">M</span></a>
     <nav>
       <div class="dropdown">
         <button class="dropbtn">Visit the Museum ▾</button>
@@ -22,7 +23,7 @@
         </div>
       </div>
       <a href="creation.html">Creation Story</a>
-      <a href="game.html">Game</a>
+      <a href="game.html">War Games</a>
       <a href="about.html">About</a>
       <a class="btn primary small" href="/#co-create">Co-Create</a>
     </nav>

--- a/rooms.html
+++ b/rooms.html
@@ -6,10 +6,11 @@
   <title>Mega-Museum — Rooms</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css" />
+  <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg" />
 </head>
 <body>
   <header class="nav">
-    <a class="brand" href="/"><span class="logo-circle">M</span><span class="brand-text">MEGA-MUSEUM</span></a>
+    <a class="brand" href="/" aria-label="Mega-Museum home"><span class="logo-circle">M</span></a>
     <nav>
       <div class="dropdown">
         <button class="dropbtn">Visit the Museum ▾</button>
@@ -19,7 +20,7 @@
         </div>
       </div>
       <a href="creation.html">Creation Story</a>
-      <a href="game.html">Game</a>
+      <a href="game.html">War Games</a>
       <a href="about.html">About</a>
       <a class="btn primary small" href="#co-create">Co-Create</a>
     </nav>


### PR DESCRIPTION
## Summary
- replace the Mega-Museum wordmark with the standalone M logo across all navigation bars
- add a reusable SVG favicon that matches the circular M mark on every page
- rename the Game navigation link and page content to War Games, including updated messaging

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e3e75b9764832d88d031c4b2d20063