### PR TITLE
Rename co-create references to Free Login

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,7 +24,7 @@
       <a href="creation.html">Creation Story</a>
       <a href="game.html">War Games</a>
       <a href="about.html">About</a>
-      <a class="btn primary small" href="/#co-create">Co-Create</a>
+      <a class="btn primary small" href="/#co-create">Free Login</a>
     </nav>
   </header>
 
@@ -70,14 +70,14 @@
       </article>
     </section>
 
-    <h3>How Co-Creation Drives the Plan</h3>
+    <h3>How Free Login Drives the Plan</h3>
     <ul class="bullets">
       <li>Community votes lock character looks (clothes, accessories, face structure, names).</li>
       <li>Polls decide which rooms and set pieces get upgraded next.</li>
       <li>Suggestions feed gags, transitions, and hidden details across all stages.</li>
     </ul>
 
-    <p class="muted small">Want to influence what happens next? <a href="/#co-create">Join the Co-Creation polls</a>.</p>
+    <p class="muted small">Want to influence what happens next? <a href="/#co-create">Join the Free Login polls</a>.</p>
 
     <h3>Credits</h3>
     <ul class="bullets">

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -171,7 +171,7 @@ body{
 .steps li::before{content:""; position:absolute; left:-7px; top:18px; width:10px; height:10px; background:var(--brand); border-radius:50%}
 .steps span{display:inline-block; min-width:64px; font-weight:700; margin-right:6px}
 
-/* ========== Co-create area (polls) ========== */
+/* ========== Free Login area (polls) ========== */
 .cocreate{padding:40px 22px 80px}
 .cocreate-card{max-width:1000px; margin:0 auto}
 .gate{display:grid; grid-template-columns:1fr auto; gap:10px; align-items:end; margin-top:10px}

--- a/creation.html
+++ b/creation.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css" />
   <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg" />
-  <meta name="description" content="The Mega-Museum Cinema — watch the co-creation story unfold in video form. Vote on what gets made next." />
+  <meta name="description" content="The Mega-Museum Cinema — watch the Free Login story unfold in video form. Vote on what gets made next." />
 
   <!-- Page-specific styles (kept here to keep this page self-contained) -->
   <style>
@@ -106,13 +106,13 @@
       <a href="creation.html">Creation Story</a>
       <a href="game.html">War Games</a>
       <a href="about.html">About</a>
-      <a class="btn primary small" href="/#co-create">Co-Create</a>
+      <a class="btn primary small" href="/#co-create">Free Login</a>
     </nav>
   </header>
 
   <main class="page-wrap narrow">
     <h1 class="page-title">The Creation Story — Cinema</h1>
-    <p>This page is the <strong>showroom</strong> for the co-creation story. While the museum rooms evolve in VR, the story itself is released here as a <strong>video series (Stage 1)</strong>. Some rooms overlap with the story, others don’t — that’s part of the fun.</p>
+    <p>This page is the <strong>showroom</strong> for the Free Login story. While the museum rooms evolve in VR, the story itself is released here as a <strong>video series (Stage 1)</strong>. Some rooms overlap with the story, others don’t — that’s part of the fun.</p>
 
     <!-- Teaser -->
     <section class="creation-hero card">
@@ -140,7 +140,7 @@
           </div>
         </div>
 
-        <a class="btn primary" href="/#co-create">Vote in Co-Creation →</a>
+        <a class="btn primary" href="/#co-create">Enter Free Login →</a>
       </div>
 
       <figure class="creation-hero-art">
@@ -268,7 +268,7 @@
       </div>
     </div>
 
-    <p class="muted small" style="margin-top:14px">Want to influence the next chapter? <a href="/#co-create">Vote in Co-Creation</a>.</p>
+    <p class="muted small" style="margin-top:14px">Want to influence the next chapter? <a href="/#co-create">Access Free Login</a>.</p>
   </main>
 
   <footer class="footer compact">

--- a/game.html
+++ b/game.html
@@ -24,7 +24,7 @@
       <a href="creation.html">Creation Story</a>
       <a href="game.html">War Games</a>
       <a href="about.html">About</a>
-      <a class="btn primary small" href="/#co-create">Co-Create</a>
+      <a class="btn primary small" href="/#co-create">Free Login</a>
     </nav>
   </header>
 
@@ -37,9 +37,9 @@
 
     <section class="card" style="margin-top:24px;">
       <h2>Be first to play</h2>
-      <p>Want to know when the prototype launches? Join the co-creation crew so you can test War Games, drop feedback, and help
+      <p>Want to know when the prototype launches? Join the Free Login crew so you can test War Games, drop feedback, and help
         decide which mechanics ship.</p>
-      <a class="btn primary" href="/#co-create">Join the Co-Creation Polls</a>
+      <a class="btn primary" href="/#co-create">Join the Free Login Polls</a>
     </section>
   </main>
 

--- a/how-to.html
+++ b/how-to.html
@@ -25,7 +25,7 @@
     <a href="creation.html">Creation Story</a>
     <a href="game.html">War Games</a>
     <a href="about.html">About</a>
-    <a class="btn primary small" href="#co-create">Co-Create</a>
+    <a class="btn primary small" href="#co-create">Free Login</a>
   </nav>
 </header>
 
@@ -43,7 +43,7 @@
       <li>Look for hotspots (glowing markers) to move.</li>
       <li>Short scenes: 1–4 minutes; longer sequences later.</li>
     </ul>
-    <p class="muted small">Questions? Ideas? Leave a suggestion inside the co-creation area on the homepage.</p>
+    <p class="muted small">Questions? Ideas? Leave a suggestion inside the Free Login area on the homepage.</p>
   </main>
 
   <footer class="footer compact">

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       <a href="creation.html">Creation Story</a>
       <a href="game.html">War Games</a>
       <a href="about.html">About</a>
-      <a class="btn primary small" href="/#co-create">Co-Create</a>
+      <a class="btn primary small" href="/#co-create">Free Login</a>
     </nav>
   </header>
 
@@ -38,7 +38,7 @@
 
       <div class="cta">
         <a class="btn" href="rooms.html">Explore Rooms →</a>
-        <a class="btn primary" href="/#co-create">Co-Create with Us</a>
+        <a class="btn primary" href="/#co-create">Free Login</a>
       </div>
 
       <p class="quick-join">
@@ -62,9 +62,9 @@
 
     <article class="card pillar">
       <div class="emoji">📊</div>
-      <h3>Co-Creation</h3>
+      <h3>Free Login</h3>
       <p>Vote in time-boxed polls, suggest new ideas, unlock future rooms. One open poll at a time — 10 total lined up.</p>
-      <a class="btn inline" href="/#co-create">Open Co-Creation →</a>
+      <a class="btn inline" href="/#co-create">Open Free Login →</a>
     </article>
   </section>
 
@@ -96,7 +96,7 @@
         </div>
 
         <div class="cta">
-          <a class="btn primary" href="/#co-create">Vote in Co-Creation →</a>
+          <a class="btn primary" href="/#co-create">Enter Free Login →</a>
           <a class="btn ghost" href="creation.html">Read the Creation Story</a>
         </div>
       </div>
@@ -119,10 +119,10 @@
     </ul>
   </section>
 
-  <!-- CO-CREATE (polls) -->
+  <!-- FREE LOGIN (polls) -->
   <section class="cocreate" id="co-create">
     <article class="card cocreate-card">
-      <h2>Co-Create with Us</h2>
+      <h2>Free Login</h2>
       <p class="muted">Enter the collaborator gate to access the live polls. It’s a friendly password — same for everyone.</p>
 
       <!-- Gate -->

--- a/rooms.html
+++ b/rooms.html
@@ -22,7 +22,7 @@
       <a href="creation.html">Creation Story</a>
       <a href="game.html">War Games</a>
       <a href="about.html">About</a>
-      <a class="btn primary small" href="#co-create">Co-Create</a>
+      <a class="btn primary small" href="#co-create">Free Login</a>
     </nav>
   </header>
 
@@ -77,7 +77,7 @@
       </article>
     </div>
 
-    <p class="muted small">Want to influence what ships next? <a href="/#co-create">Join the co-creation polls</a>.</p>
+    <p class="muted small">Want to influence what ships next? <a href="/#co-create">Join the Free Login polls</a>.</p>
   </main>
 
   <footer class="footer compact">


### PR DESCRIPTION
## Summary
- rename site navigation and call-to-action text from Co-Create to Free Login across the homepage and subpages
- refresh supporting copy to consistently refer to the Free Login experience, including meta descriptions and helper text
- update stylesheet comments to match the new Free Login terminology for the polls section

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3e9e72a84832d9559dfd9dc040624