### PR TITLE
Make homepage navigation hover glass effect

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -27,9 +27,31 @@ body{
 
 /* ========== Top nav ========== */
 .nav{
-  position:sticky; top:0; z-index:60;
+  position:relative; z-index:60;
   display:flex; align-items:center; justify-content:center; gap:28px;
   padding:20px clamp(22px, 4vw, 60px);
+  background:rgba(15,23,42,.45);
+  border-bottom:1px solid rgba(148,163,184,.25);
+  backdrop-filter:blur(14px) saturate(160%);
+  transition:background .3s ease, border-color .3s ease, backdrop-filter .3s ease;
+}
+
+.nav:hover,
+.nav:focus-within{
+  background:rgba(15,23,42,.55);
+  border-bottom:1px solid rgba(148,163,184,.35);
+  backdrop-filter:blur(16px) saturate(180%);
+}
+
+.has-hero .nav{
+  position:absolute; left:0; right:0; top:0;
+  background:transparent;
+  border-bottom:1px solid transparent;
+  backdrop-filter:blur(0px) saturate(120%);
+}
+
+.has-hero .nav:hover,
+.has-hero .nav:focus-within{
   background:rgba(15,23,42,.45);
   border-bottom:1px solid rgba(148,163,184,.25);
   backdrop-filter:blur(14px) saturate(160%);

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg" />
   <meta name="description" content="Start inside simple prototype rooms. Return to see them transform. Vote on what gets built next." />
 </head>
-<body>
+<body class="has-hero">
 
   <!-- NAV -->
   <header class="nav">


### PR DESCRIPTION
## Summary
- stop the global navigation from sticking to the viewport so it scrolls away naturally
- add hover-driven glass styling while keeping a transparent idle state over the homepage hero video
- apply a homepage body class so the hero video can sit behind the menu without impacting inner pages

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5368a4138832d8604f6cff034f005