### PR TITLE
Restyle experience menu to single-column hover reveal

### DIFF
--- a/assets/img/creation/game-preview.svg
+++ b/assets/img/creation/game-preview.svg
@@ -1,0 +1,34 @@
+<svg width="480" height="360" viewBox="0 0 480 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gameBg" x1="40" y1="30" x2="420" y2="330" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ecfeff" />
+      <stop offset="1" stop-color="#cffafe" />
+    </linearGradient>
+    <linearGradient id="gameGlow" x1="140" y1="110" x2="360" y2="260" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0ea5e9" stop-opacity="0.7" />
+      <stop offset="1" stop-color="#38bdf8" stop-opacity="0.4" />
+    </linearGradient>
+    <filter id="glow" x="0" y="0" width="480" height="360" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="24" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="480" height="360" rx="42" fill="url(#gameBg)" />
+  <g filter="url(#glow)">
+    <circle cx="240" cy="188" r="118" fill="url(#gameGlow)" />
+    <rect x="162" y="120" width="156" height="116" rx="30" fill="#0ea5e9" fill-opacity="0.85" />
+    <rect x="182" y="140" width="116" height="76" rx="20" fill="#0f172a" fill-opacity="0.9" />
+    <circle cx="204" cy="234" r="18" fill="#f1f5f9" />
+    <circle cx="276" cy="234" r="18" fill="#f1f5f9" />
+    <path d="M204 226v16" stroke="#0ea5e9" stroke-width="6" stroke-linecap="round" />
+    <path d="M196 234h16" stroke="#0ea5e9" stroke-width="6" stroke-linecap="round" />
+    <path d="M268 234h16" stroke="#0ea5e9" stroke-width="6" stroke-linecap="round" />
+    <path d="M276 226v16" stroke="#0ea5e9" stroke-width="6" stroke-linecap="round" />
+    <circle cx="232" cy="178" r="18" fill="#38bdf8" />
+    <path d="M226 178l8-6v12l-8-6z" fill="#f8fafc" />
+  </g>
+  <path d="M64 78c22 12 46 32 90 26 70-10 90-54 150-44 54 8 70 56 132 66" stroke="#0ea5e9" stroke-opacity="0.25" stroke-width="8" stroke-linecap="round" />
+</svg>

--- a/assets/img/creation/vote-preview.svg
+++ b/assets/img/creation/vote-preview.svg
@@ -1,0 +1,28 @@
+<svg width="480" height="360" viewBox="0 0 480 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="voteGradient" x1="0" y1="0" x2="480" y2="360" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff7ed" />
+      <stop offset="1" stop-color="#fee2e2" />
+    </linearGradient>
+    <linearGradient id="voteCard" x1="80" y1="80" x2="360" y2="280" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fef3c7" />
+      <stop offset="1" stop-color="#fbcfe8" />
+    </linearGradient>
+    <filter id="shadow" x="0" y="0" width="480" height="360" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="24" flood-color="rgba(190,24,93,0.28)" />
+    </filter>
+  </defs>
+  <rect width="480" height="360" rx="42" fill="url(#voteGradient)" />
+  <g filter="url(#shadow)">
+    <rect x="84" y="70" width="312" height="220" rx="28" fill="white" fill-opacity="0.86" />
+    <rect x="104" y="92" width="272" height="180" rx="20" fill="url(#voteCard)" />
+    <rect x="124" y="116" width="152" height="28" rx="14" fill="#1f2937" fill-opacity="0.16" />
+    <rect x="124" y="166" width="192" height="28" rx="14" fill="#1f2937" fill-opacity="0.16" />
+    <rect x="124" y="216" width="132" height="28" rx="14" fill="#1f2937" fill-opacity="0.16" />
+    <circle cx="340" cy="130" r="22" fill="#f97316" />
+    <path d="M330 130l8.5 8.5L350 127" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="340" cy="180" r="22" fill="#f87171" fill-opacity="0.4" />
+    <circle cx="340" cy="230" r="22" fill="#f87171" fill-opacity="0.2" />
+  </g>
+  <path d="M60 292c48 28 120 50 180 18 78-42 136 14 180 0" stroke="#f97316" stroke-opacity="0.3" stroke-width="6" stroke-linecap="round" />
+</svg>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -176,6 +176,167 @@ header.nav:hover + .hero .hero-video video,
 header.nav:focus-within + .hero .hero-video video{ filter:blur(8px) saturate(80%); }
 .hero .overline{color:rgba(255,255,255,.7)}
 
+/* ========== Experience menu ========== */
+.experience-menu{
+  position:relative;
+  padding:clamp(56px, 12vw, 120px) 22px clamp(52px, 10vw, 110px);
+  background:linear-gradient(180deg, rgba(15,23,42,.06) 0%, rgba(241,245,249,0.85) 45%, rgba(248,250,252,1) 100%);
+}
+
+.experience-menu__inner{
+  max-width:1100px;
+  margin:0 auto;
+  display:grid;
+  gap:32px;
+}
+
+.experience-menu__intro h2{
+  margin:8px 0 16px;
+  font-size:clamp(2.1rem, 4.5vw, 3.1rem);
+  line-height:1.08;
+}
+
+.experience-menu__intro p{max-width:520px;}
+
+.experience-menu__list{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  border-top:1px solid rgba(15,23,42,.12);
+  background:rgba(255,255,255,.7);
+  border-radius:28px;
+  overflow:hidden;
+  box-shadow:0 28px 70px rgba(15,23,42,.12);
+}
+
+.experience-menu__item{
+  --menu-accent:var(--brand);
+  position:relative;
+  display:flex;
+  align-items:center;
+  gap:clamp(18px, 3vw, 40px);
+  padding:clamp(22px, 4.5vw, 48px) clamp(18px, 4vw, 44px);
+  color:var(--ink);
+  text-decoration:none;
+  font-weight:800;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  font-size:clamp(2.2rem, 6vw, 3.6rem);
+  line-height:1.02;
+  border-bottom:1px solid rgba(15,23,42,.1);
+  transition:color .35s ease, background .35s ease, transform .45s cubic-bezier(.22,1,.36,1);
+  z-index:0;
+}
+
+.experience-menu__item:last-child{border-bottom:none;}
+
+.experience-menu__item::before{
+  content:"";
+  position:absolute;
+  inset:12px clamp(14px, 2.6vw, 36px);
+  border-radius:22px;
+  background:linear-gradient(135deg, rgba(255,255,255,.92) 0%, rgba(255,255,255,.55) 100%);
+  opacity:0;
+  transform:scale(.95);
+  transition:opacity .4s ease, transform .45s cubic-bezier(.22,1,.36,1), box-shadow .45s ease;
+  z-index:-1;
+}
+
+.experience-menu__index{font-size:clamp(1rem, 2vw, 1.2rem); letter-spacing:.3em; color:rgba(15,23,42,.35); min-width:46px; display:inline-flex; align-items:center;}
+
+.experience-menu__label{flex:1;}
+
+.experience-menu__arrow{
+  margin-left:auto;
+  font-size:clamp(2rem, 5vw, 3rem);
+  transition:transform .45s cubic-bezier(.22,1,.36,1);
+}
+
+.experience-menu__media{
+  position:absolute;
+  left:100%;
+  top:50%;
+  margin-left:clamp(18px, 4vw, 42px);
+  width:clamp(200px, 28vw, 320px);
+  border-radius:28px;
+  overflow:hidden;
+  box-shadow:0 34px 80px rgba(15,23,42,.22);
+  transform:translate(40px,-50%) scale(.9);
+  opacity:0;
+  transition:opacity .45s ease, transform .55s cubic-bezier(.22,1,.36,1);
+  pointer-events:none;
+}
+
+.experience-menu__media img{display:block; width:100%; height:100%; object-fit:cover;}
+
+.experience-menu__item:focus-visible{outline:none;}
+
+.experience-menu__item:hover,
+.experience-menu__item:focus-visible{
+  color:var(--menu-accent);
+  transform:translateX(6px);
+}
+
+.experience-menu__item:hover .experience-menu__index,
+.experience-menu__item:focus-visible .experience-menu__index{color:var(--menu-accent);}
+
+.experience-menu__item:hover::before,
+.experience-menu__item:focus-visible::before{
+  opacity:1;
+  transform:scale(1);
+  box-shadow:0 24px 60px rgba(15,23,42,.2);
+}
+
+.experience-menu__item:hover .experience-menu__arrow,
+.experience-menu__item:focus-visible .experience-menu__arrow{
+  transform:translateX(10px);
+}
+
+.experience-menu__item:hover .experience-menu__media,
+.experience-menu__item:focus-visible .experience-menu__media{
+  opacity:1;
+  transform:translate(0,-50%) scale(1);
+}
+
+@media (max-width: 1100px){
+  .experience-menu__list{padding-right:clamp(0px, 4vw, 80px);}
+}
+
+@media (max-width: 900px){
+  .experience-menu__item{
+    flex-wrap:wrap;
+    gap:16px;
+  }
+
+  .experience-menu__arrow{order:3; width:100%; text-align:left; font-size:clamp(1.6rem, 6vw, 2.4rem);}
+
+  .experience-menu__media{
+    position:relative;
+    left:auto;
+    top:auto;
+    margin-left:0;
+    margin-top:12px;
+    width:100%;
+    opacity:0;
+    transform:translateY(12px) scale(.96);
+  }
+
+  .experience-menu__item:hover .experience-menu__media,
+  .experience-menu__item:focus-visible .experience-menu__media{
+    transform:translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .experience-menu__item,
+  .experience-menu__item::before,
+  .experience-menu__arrow,
+  .experience-menu__media{
+    transition-duration:.01ms !important;
+    transition-delay:0ms !important;
+  }
+}
+
 /* ========== Pillars / Cards ========== */
 .pillars{
   display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr));

--- a/index.html
+++ b/index.html
@@ -57,6 +57,46 @@
     </div>
   </section>
 
+  <!-- EXPERIENCE MENU -->
+  <section class="experience-menu" aria-label="Choose your Mega-Museum experience">
+    <div class="experience-menu__inner">
+      <div class="experience-menu__intro">
+        <p class="overline">We guide</p>
+        <h2>Pick a pathway into the Mega-Museum universe.</h2>
+        <p class="muted">Hover or focus each line to see the world you&rsquo;re about to enter. The colour shift and image preview echo the way our collaborators browse the museum.</p>
+      </div>
+
+      <div class="experience-menu__list">
+        <a class="experience-menu__item" href="rooms.html" style="--menu-accent:#eab308;">
+          <span class="experience-menu__index">01</span>
+          <span class="experience-menu__label">Tour the Museum</span>
+          <span class="experience-menu__arrow" aria-hidden="true">→</span>
+          <span class="experience-menu__media" aria-hidden="true">
+            <img src="assets/img/creation/characters-teaser.png" alt="" loading="lazy" />
+          </span>
+        </a>
+
+        <a class="experience-menu__item" href="/#co-create" style="--menu-accent:#ef4444;">
+          <span class="experience-menu__index">02</span>
+          <span class="experience-menu__label">Vote on the Story</span>
+          <span class="experience-menu__arrow" aria-hidden="true">→</span>
+          <span class="experience-menu__media" aria-hidden="true">
+            <img src="assets/img/creation/vote-preview.svg" alt="" loading="lazy" />
+          </span>
+        </a>
+
+        <a class="experience-menu__item" href="game.html" style="--menu-accent:#38bdf8;">
+          <span class="experience-menu__index">03</span>
+          <span class="experience-menu__label">Play the Game</span>
+          <span class="experience-menu__arrow" aria-hidden="true">→</span>
+          <span class="experience-menu__media" aria-hidden="true">
+            <img src="assets/img/creation/game-preview.svg" alt="" loading="lazy" />
+          </span>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <!-- PILLARS -->
   <section class="pillars">
     <article class="card pillar">


### PR DESCRIPTION
## Summary
- redesign the homepage experience menu into a single-column stack with oversized typographic links
- animate hover and focus states to shift the accent colour and reveal contextual imagery, echoing the Aardman interaction style
- add bespoke SVG preview art for the voting and game pathways used by the hover reveals

## Testing
- Not run (static HTML/CSS updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e53f1674ec832d83709ad72f89d03c