### PR TITLE
Remove obsolete front page cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,23 +97,6 @@
     </div>
   </section>
 
-  <!-- PILLARS -->
-  <section class="pillars">
-    <article class="card pillar">
-      <div class="emoji">🕹️</div>
-      <h3>Explore Rooms</h3>
-      <p>From sketch to space: walk early rooms now. Each one has a clear status — Prototype, In-Progress, or Live.</p>
-      <a class="btn inline" href="rooms.html">Explore Rooms →</a>
-    </article>
-
-    <article class="card pillar">
-      <div class="emoji">📊</div>
-      <h3>Free Login</h3>
-      <p>Vote in time-boxed polls, suggest new ideas, unlock future rooms. One open poll at a time — 10 total lined up.</p>
-      <a class="btn inline" href="/#co-create">Open Free Login →</a>
-    </article>
-  </section>
-
   <!-- CHARACTERS SECTION (before voting) -->
   <section class="characters" id="characters">
     <div class="char-wrap card">


### PR DESCRIPTION
## Summary
- remove the Explore Rooms and Free Login cards from the home page pillars section

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68e5457a23bc832da309b57d847bfc7d